### PR TITLE
Add 286 Support for Bleeding-Edge Systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ endif
 
 include config.mk
 
+ASFLAGS += -DTARGET=${TARGET} -DFDDSIZE=${FDDSIZE}
+
 all: config.mk floppy
 
 config.mk:
@@ -56,13 +58,13 @@ config.mk:
 
 %.o: %.asm
 	@$(call STATUS,"ASSEMBLE",$^)
-	@${ASM} ${ASFLAGS} ${ASDEBUG} -DTARGET=${TARGET} -o $@ $<
+	@${ASM} ${ASFLAGS} ${ASDEBUG} -o $@ $<
 
 fdd: floppy
 floppy: ${OBJFILES}
 	@$(call STATUS,"FDD IMG ",$^)
-	@dd bs=1024 count=1440 if=/dev/zero of=${FDDFILE}
-	@mkfs.msdos ${FDDFILE}
+	@dd bs=1024 count=${FDDSIZE} if=/dev/zero of=${FDDFILE}
+	#@mkfs.msdos ${FDDFILE}
 	@dd bs=512 count=1 if=${LOADERDIR}/${LOADERNAME}.o of=${FDDFILE} conv=notrunc
 	@dd bs=512 count=2 seek=1 if=${STAGE2DIR}/${STAGE2NAME}.o of=${FDDFILE} conv=notrunc
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ config.mk:
 
 %.o: %.asm
 	@$(call STATUS,"ASSEMBLE",$^)
-	@${ASM} ${ASFLAGS} ${ASDEBUG} -o $@ $<
+	@${ASM} ${ASFLAGS} ${ASDEBUG} -DTARGET=${TARGET} -o $@ $<
 
 fdd: floppy
 floppy: ${OBJFILES}

--- a/config.mk
+++ b/config.mk
@@ -4,3 +4,4 @@ AR     := ar
 RANLIB := ranlib
 LD     := ld
 TARGET := 386
+FDDSIZE := 1440

--- a/config.mk
+++ b/config.mk
@@ -3,3 +3,4 @@ ASM    := nasm
 AR     := ar
 RANLIB := ranlib
 LD     := ld
+TARGET := 386

--- a/src/mbr/a20_enable.asm
+++ b/src/mbr/a20_enable.asm
@@ -1,4 +1,5 @@
 bits 16
+cpu TARGET
 
 enable_a20:
   cli
@@ -13,14 +14,22 @@ enable_a20:
 
   call .a20wait2
   in al, 0x60
-  push eax
+  %ifidni TARGET, 286
+    push ax
+  %else
+    push eax
+  %endif
 
   call .a20wait
   mov al, 0xd1
   out 0x64, al
 
   call .a20wait
-  pop eax
+  %ifidni TARGET, 286
+    pop ax
+  %else
+    pop eax
+  %endif
   or al, 2
   out 0x60, al
 

--- a/src/mbr/bios_parameter_block.asm
+++ b/src/mbr/bios_parameter_block.asm
@@ -1,3 +1,5 @@
+cpu TARGET
+
 section .text
 
 BytesPerSector      equ    0x000B

--- a/src/mbr/load_stage2_floppy.asm
+++ b/src/mbr/load_stage2_floppy.asm
@@ -29,7 +29,11 @@ load_stage2_floppy:
   mov es, ax
   mov bx, 0x0
   mov ah, 0x02
+%ifidn FDDSIZE, 360
+  mov al, 0x06
+%else
   mov al, 0x9
+%endif
   mov ch, 0x0
   mov cl, 0x3
   mov dh, 0x0

--- a/src/mbr/load_stage2_floppy.asm
+++ b/src/mbr/load_stage2_floppy.asm
@@ -1,3 +1,5 @@
+cpu TARGET
+
 load_stage2_floppy:
   ; Reset drives
   mov ah, 0x0

--- a/src/mbr/load_stage2_hdd.asm
+++ b/src/mbr/load_stage2_hdd.asm
@@ -1,3 +1,5 @@
+cpu TARGET
+
 load_stage2_hdd:
   mov si, data_address_packet
   mov ah, 0x42  ; ?

--- a/src/mbr/loader.asm
+++ b/src/mbr/loader.asm
@@ -36,7 +36,9 @@ _start:
   print Stage2LoadFDD
 
   call load_stage2_floppy       ; Attempt to load stage2 from floppy disk.
+%ifidni TARGET, 386             ; 286s will not have int 13h, subfunction 42h.
   jc  .stage2_load_error_floppy ; Go to error handler if load failed.
+%endif
   jmp .run_stage2               ; Run stage2 if load succeeded.
 
   .stage2_load_error_floppy:

--- a/src/mbr/loader.asm
+++ b/src/mbr/loader.asm
@@ -1,3 +1,4 @@
+cpu TARGET
 bits 16
 org 0x7c00
 
@@ -57,9 +58,15 @@ _start:
     lgdt [gdt_desc]
 
     ; Switch to protected mode
-    mov eax, cr0
-    or eax, 1
-    mov cr0, eax
+    %ifidni TARGET, 286
+        smsw ax
+        or ax, 1
+        lmsw ax
+    %else
+        mov eax, cr0
+        or eax, 1
+        mov cr0, eax
+    %endif
 
     ; TODO: Figure out how to store 0x7e00 somewhere.
     jmp 0x08:0x7e00   ; 0x7e00 needs to match load_stage2_*.asm.
@@ -84,16 +91,34 @@ gdt_code:
   dw 0
   db 0
   db 10011010b
-  db 11001111b
-  db 0
+  %ifidni TARGET, 286
+    dw 0
+  %else
+    db 11001111b
+    db 0
+  %endif
 
 gdt_data:
   dw 0xffff
   dw 0
   db 0
   db 10010010b
-  db 11001111b
-  db 0
+  %ifidni TARGET, 286
+      dw 0
+  %else
+    db 11001111b
+    db 0
+  %endif
+
+;Segments can only be 64kB on 286, so let's define a video segment!
+%ifidn TARGET, 286
+gdt_video:
+    dw 0xffff
+    dw 0
+    db 0xb ;0x0b0000
+    db 10010010b
+    dw 0
+%endif
 
 gdt_end:
 

--- a/src/mbr/print.asm
+++ b/src/mbr/print.asm
@@ -1,3 +1,5 @@
+cpu TARGET
+
 bits 16
 
 _print:

--- a/src/stage2/stage2.asm
+++ b/src/stage2/stage2.asm
@@ -1,18 +1,37 @@
-bits 32
+cpu TARGET
+%ifidn TARGET, 286
+    bits 16
+%else
+    bits 32
+%endif
 org 0x7e00
 
 mov ax, 0x10
 mov ds, ax
-mov es, ax
-mov fs, ax
-mov gs, ax
 mov ss, ax
+%ifidn TARGET, 386
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+%endif
 
-mov byte [ds:0xb8000], 'a'
-mov byte [ds:0xb8001], 0x2f
 
-mov esp, 0x90000
+%ifidn TARGET, 286
+    mov ax, 0x18 ;Our shiny new video segment.
+    mov es, ax
+    
+    mov byte [es:0x8000], 'a'
+    mov byte [es:0x8001], 0x2f
+    mov sp, 0x9000 ;SS == DS
+    mov byte [es:0x8000], 'b'
 
-mov byte [ds:0xb8000], 'b'
+%else
+    mov byte [ds:0xb8000], 'a'
+    mov byte [ds:0xb8001], 0x2f
+    
+    mov esp, 0x90000
+    
+    mov byte [ds:0xb8000], 'b'
+%endif
 
 hlt


### PR DESCRIPTION
I was quite bothered by the lack of 286 support for your bootloader in 2015. These machines are not getting any younger and deserve to be used to their full potential, which includes running current and generating heat through the 150,000 gates or so that make up Protected Mode on these unappreciated CPUs :).

I promise 286 support, being the cutting edge of computing that will change the world by never going obsolete, will lead to significantly increased revenue and attention to this project :D.
